### PR TITLE
jenkinx-node-test to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jenkinx-node-test
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6


### PR DESCRIPTION
Promote jenkinx-node-test to version 0.0.6